### PR TITLE
Switch to PEP 440-compliant version numbers

### DIFF
--- a/version.py
+++ b/version.py
@@ -47,10 +47,10 @@ def call_git_describe(abbrev=4):
         # keep the version number based on the latest tag
         # on the branch, plus the number of commits since
         # that tag
-        lastest_tag = split_version[0]
+        latest_tag = split_version[0]
         number_of_commits_since_tag = split_version[1]
 
-        return '{:}.{:}'.format(lastest_tag, number_of_commits_since_tag)
+        return '{:}.{:}'.format(latest_tag, number_of_commits_since_tag)
 
     except:
         return None

--- a/version.py
+++ b/version.py
@@ -42,7 +42,15 @@ def call_git_describe(abbrev=4):
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]
-        return line.decode("ascii").strip()
+        version = line.decode("ascii").strip()
+        split_version = version.split('-')
+        # keep the version number based on the latest tag
+        # on the branch, plus the number of commits since
+        # that tag
+        lastest_tag = split_version[0]
+        number_of_commits_since_tag = split_version[1]
+
+        return '{:}.{:}'.format(lastest_tag, number_of_commits_since_tag)
 
     except:
         return None


### PR DESCRIPTION
Our version.py script used to return version numbers looking like `0.1.1-6-gbab2` (`latest tag on the branch`-`number of commits since that tag`-g`4 hexadecimal digits of the latest commit ID`), which is not compliant with PEP 440, and thus refused by setuptools 66.0.0. This new version returns instead `0.1.1.6` (`latest tag on the branch`.`number of commits since that tag`) which is a canonical version as described in PEP 440.